### PR TITLE
refactor: return custom exp name if it is set

### DIFF
--- a/scripts/f_environment.py
+++ b/scripts/f_environment.py
@@ -152,7 +152,7 @@ def validate_config(config):
         else:
             experiment_name += f"_sd{config.SEED}"
 
-        return experiment_name
+        return experiment_name if not config.EXPERIMENT_NAME else config.EXPERIMENT_NAME
     
     experiment_name += f"_sd{config.SEED}"
 

--- a/scripts/f_environment.py
+++ b/scripts/f_environment.py
@@ -156,7 +156,7 @@ def validate_config(config):
     
     experiment_name += f"_sd{config.SEED}"
 
-    return experiment_name
+    return experiment_name if not config.EXPERIMENT_NAME else config.EXPERIMENT_NAME
 
 def find_seed_in_weight(weight_name):
     match = re.search(r'sd(\d+)', weight_name)


### PR DESCRIPTION
For now experiment name returned in automatic way, no matter if is set in config or not.